### PR TITLE
Remove duplicate width declaration in CSS

### DIFF
--- a/autohide.css
+++ b/autohide.css
@@ -10,7 +10,6 @@
 
   .navigation__secondary-autohide--hidden {
     transform: translateY( -100% );
-    width: 100%;
   }
 
   .navigation__secondary-autohide--nohide {


### PR DESCRIPTION
Btw, I don't think the first time you set width:100% is actually necessary, width:auto is already implicit.
